### PR TITLE
Add PutNX method on bucket

### DIFF
--- a/buckets.go
+++ b/buckets.go
@@ -70,6 +70,18 @@ func (bk *Bucket) Put(k, v []byte) error {
 	})
 }
 
+// PutNX (put-if-not-exists) inserts value `v` with key `k` 
+// if key doesn't exist.
+func (bk *Bucket) PutNX(k, v []byte) error {
+	v, err := bk.Get(k)
+	if v != nil || err != nil {
+		return err
+	}
+	return bk.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bk.Name).Put(k, v)
+	})
+}
+
 // Insert iterates over a slice of k/v pairs, putting each item in
 // the bucket as part of a single transaction.  For large insertions,
 // be sure to pre-sort your items (by Key in byte-sorted order), which


### PR DESCRIPTION
We added a PutNX (put-if-not-exists) method on the bucket type. This let's you
put a key/val if key doesn't already exist.  The value is not updated if key
already exists.

Note that this is analogous to redis's [SETNX](http://redis.io/commands/setnx).

This was added as a response to the feature request in [issue 2](https://github.com/joyrexus/buckets/issues/2).
