### PR TITLE
Add InsertNX method on Bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Since Bolt stores keys in [byte-sorted order](https://github.com/boltdb/bolt#ite
 
 #### Read/write transactions
 
-* [`Put(k, v)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Put) - save item
+* [`Put(k, v)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Put) - save/update item
+* [`PutNX(k, v)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Put) - save item if key does not exist
 * [`Delete(k)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Delete) - delete item
-* [`Insert(items)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Insert) - save items (k/v pairs)
+* [`Insert(items)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Insert) - save/update items (k/v pairs)
+* [`InsertNX(items)`](https://godoc.org/github.com/joyrexus/buckets#Bucket.Insert) - for each item (k/v pair), save item if key does not exist
 
 
 #### Read-only transactions

--- a/buckets.go
+++ b/buckets.go
@@ -95,6 +95,22 @@ func (bk *Bucket) Insert(items []struct{ Key, Value []byte }) error {
 	})
 }
 
+// InsertNX (insert-if-not-exists) iterates over a slice of k/v pairs, 
+// putting each item in the bucket as part of a single transaction.  
+// Unlike Insert, however, InsertNX will not update the value for an 
+// existing key.
+func (bk *Bucket) InsertNX(items []struct{ Key, Value []byte }) error {
+	return bk.db.Update(func(tx *bolt.Tx) error {
+		for _, item := range items {
+			v, _ := bk.Get(item.Key)
+			if v == nil {
+				tx.Bucket(bk.Name).Put(item.Key, item.Value)
+			}
+		}
+		return nil
+	})
+}
+
 // Delete removes key `k`.
 func (bk *Bucket) Delete(k []byte) error {
 	return bk.db.Update(func(tx *bolt.Tx) error {


### PR DESCRIPTION
We added an InsertNX (insert-if-not-exists) method on the Bucket type.  This
let's you insert a key/val if key doesn't already exist. The value is not
updated if key already exists.

This was added as a response to the feature request in [issue 2](https://github.com/joyrexus/buckets/issues/2).
